### PR TITLE
fix: correct footer links

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -16,7 +16,7 @@ const Footer = () => {
     },
     {
       title: 'Contact Us',
-      path: '/contact-us'
+      path: '/contact'
     },
     {
       title: 'Help',


### PR DESCRIPTION
some links will still show a blank page because the designer didn't provide the design for the following pages, so he/she can either provide the pages or delete the footer links from the design. the pages includes:
- privacy
- benefit
- help
- terms and conditions

cc @Benardboye 